### PR TITLE
Removed deprecated 'U'

### DIFF
--- a/mantaray/scripts/mwa_client.py
+++ b/mantaray/scripts/mwa_client.py
@@ -131,7 +131,7 @@ def parse_row(row):
 
 def parse_csv(filename):
     result = []
-    with open(filename, 'rU') as csvfile:
+    with open(filename, 'r') as csvfile:
         reader = csv.reader(csvfile)
         for row in reader:
             if not row:


### PR DESCRIPTION
Altered this line (`rU` -> `r`) because it broke in my Python 3.11.3 environment:
https://github.com/MWATelescope/manta-ray-client/blob/daa0386c3842e4590801bdd9e86ddfeea7c58d8a/mantaray/scripts/mwa_client.py#L134