### PR TITLE
Force urllib3 version to avoid awkward ssl module dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests>=2.18.3
 websocket_client
 colorama
+urllib3==1.26.8


### PR DESCRIPTION
Later versions of `urllib3` have [dropped support for OpenSSL<1.1.1](https://github.com/urllib3/urllib3/issues/2168). Installations of manta-ray-client on sufficiently old versions of Python (confirmed for 3.8.2, which is the latest version currently supported on Garrawarla) will cause the following error:

```
$ mwa_client -l
Traceback (most recent call last):
  File "./mwa_client", line 11, in <module>
    load_entry_point('mantaray-client==1.2.3', 'console_scripts', 'mwa_client')()
  File "/pawsey/mwa_sles12sp4/apps/gcc/4.8.5/python/3.8.2/lib/python3.8/site-packages/pkg_resources/__init__.py", line 489, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/pawsey/mwa_sles12sp4/apps/gcc/4.8.5/python/3.8.2/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2852, in load_entry_point
    return ep.load()
  File "/pawsey/mwa_sles12sp4/apps/gcc/4.8.5/python/3.8.2/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2443, in load
    return self.resolve()
  File "/pawsey/mwa_sles12sp4/apps/gcc/4.8.5/python/3.8.2/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2449, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "<frozen zipimport>", line 259, in load_module
  File "/pawsey/mwa/software/python3/manta-ray-client/1.2/lib/python3.8/site-packages/mantaray_client-1.2.3-py3.8.egg/mantaray/scripts/mwa_client.py", line 5, in <module>
  File "/pawsey/mwa/software/python3/manta-ray-client/1.2/lib/python3.8/site-packages/requests-2.30.0-py3.8.egg/requests/__init__.py", line 43, in <module>
    import urllib3
  File "/pawsey/mwa/software/python3/manta-ray-client/1.2/lib/python3.8/site-packages/urllib3-2.0.2-py3.8.egg/urllib3/__init__.py", line 38, in <module>
    raise ImportError(
ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with OpenSSL 1.0.2p-fips  14 Aug 2018. See: https://github.com/urllib3/urllib3/issues/2168
```

My suggested workaround is to enforce an older version of `urllib3`. I have tested this in Python 3.8.2 and 3.10.9 environments.